### PR TITLE
Fix placeholders layout on DonkiEventDetailsScreen

### DIFF
--- a/app/src/main/kotlin/org/equeim/spacer/ui/screens/donki/details/DonkiEventDetailsScreen.kt
+++ b/app/src/main/kotlin/org/equeim/spacer/ui/screens/donki/details/DonkiEventDetailsScreen.kt
@@ -101,18 +101,15 @@ private fun ScreenContent(
             refreshing = showRefreshIndicator,
             onRefresh = model::refresh
         )
-        Box(
-            Modifier
-                .pullRefresh(pullRefreshState)
-        ) {
+        Box(Modifier.pullRefresh(pullRefreshState)) {
             val contentState by model.contentState.collectAsState()
-            Crossfade(
-                contentState,
-                Modifier
-                    .verticalScroll(rememberScrollState())
-                    .padding(contentPadding.addBottomInsetUnless(contentPadding.hasBottomPadding))
-            ) { state ->
-                Box(Modifier.fillMaxSize()) {
+            Crossfade(contentState) { state ->
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(contentPadding.addBottomInsetUnless(contentPadding.hasBottomPadding))
+                ) {
                     when (state) {
                         is Empty -> Unit
                         is LoadingPlaceholder -> ScreenContentLoadingPlaceholder()


### PR DESCRIPTION
We can't use fillMaxSize/fillMaxHeight inside scrollable composable.